### PR TITLE
Remove SMS_SENT metric as this should be created afer being successfully handled from SQS consumer

### DIFF
--- a/lib/routes/notify/index.js
+++ b/lib/routes/notify/index.js
@@ -30,7 +30,6 @@ const { verificationInsert } = require('./query')
  *
  * Metrics Written:
  *  SMS_FAIL: Valid mobile provided but failure adding to the SQS queue
- *  SMS_SENT: Added SMS message to SQS queue
  *  VERIFICATION_CODE_GENERATED: generated and returned verification code
  *  VERIFICATION_CODE_FAIL: unhandled error, verification code not returned
  *
@@ -129,7 +128,6 @@ async function notify(server, options, done) {
       }
 
       await sqs.sendMessage(message).promise()
-      await writeMetric(log, 'SMS_SENT')
 
       return true
     } catch (error) {

--- a/lib/routes/notify/notify.test.js
+++ b/lib/routes/notify/notify.test.js
@@ -94,7 +94,7 @@ describe('notify via sqs', () => {
 
     expect(response.statusCode).toEqual(200)
     expect(mockSelect).toHaveBeenCalledTimes(1)
-    expect(mockInsert).toHaveBeenCalledTimes(3)
+    expect(mockInsert).toHaveBeenCalledTimes(2)
     expect(mockSend).toHaveBeenCalledTimes(1)
 
     expect(payload).toEqual(


### PR DESCRIPTION
The `SMS_SENT` metric should be created after the SQS consumer (the `sms` lambda) successfully processes the request and hands the request off to the SMS provider.